### PR TITLE
Only allow expected keys for hmac

### DIFF
--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -353,7 +353,9 @@ class BasicShopifyAPI implements SessionAware, ClientAware
         ) {
             // Grab the HMAC, remove it from the params, then sort the params for hashing
             $hmac = $params['hmac'];
-            unset($params['hmac']);
+            $params = array_filter($params, function($v,$k) {
+                return in_array($k, ['code', 'shop', 'timestamp']);
+            }, ARRAY_FILTER_USE_BOTH);
             ksort($params);
 
             // Encode and hash the params (without HMAC), add the API secret, and compare to the HMAC from params

--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -353,7 +353,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
         ) {
             // Grab the HMAC, remove it from the params, then sort the params for hashing
             $hmac = $params['hmac'];
-            $params = array_filter($params, function($v,$k) {
+            $params = array_filter($params, function($v, $k) {
                 return in_array($k, ['code', 'shop', 'timestamp']);
             }, ARRAY_FILTER_USE_BOTH);
             ksort($params);

--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -353,7 +353,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
         ) {
             // Grab the HMAC, remove it from the params, then sort the params for hashing
             $hmac = $params['hmac'];
-            $params = array_filter($params, function($v, $k) {
+            $params = array_filter($params, function ($v, $k) {
                 return in_array($k, ['code', 'shop', 'timestamp']);
             }, ARRAY_FILTER_USE_BOTH);
             ksort($params);


### PR DESCRIPTION
This filters the params array to the list of keys expected so extraneous keys don't interfere with the hmac calculation.

This fixes a redirect to login after authenticate which is partly related to osiset/laravel-shopify#522 and fixes osiset/laravel-shopify#531 (I think).  It might also be related to osiset/laravel-shopify#498.