### PR TITLE
Add support for Guzzle 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=7.2.0",
-    "guzzlehttp/guzzle": "^6.5",
+    "guzzlehttp/guzzle": "^6.5|^7.0",
     "caseyamcl/guzzle_retry_middleware": "^2.3"
   },
   "require-dev": {


### PR DESCRIPTION
Fixes #82 

Laravel 8.x now requires Guzzle 7.0, causing an incompatibility with the latest version of Laravel. Would be great if 7.0 can be added to this package as well. I tried installing guzzle 7 on my local and ran the unit tests and they all passed, but I'm not sure how to update the tests on Github actions to also cover Guzzle 7. 

For reference, here's the upgrade guide to Guzzle 7. Don't think anything in this package conflicts with this list since all tests are still passing (at least on my local).