### PR TITLE
Fix microseconds in GraphQL rate limit and new option to use or not library's rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ For GraphQL, it ensures you do not use more than the default of 50 points per se
 
 To adjust the default limits, use the option class' `setRestLimit` and `setGraphLimit`.
 
+You can use your own rate limit method by using the option class' `setUseRateLimit` and `getUseRateLimit`. If you can use your own method
+```php
+// Create options for the API
+$options = new Options();
+$options->setUseRateLimit(false);
+```
+
 ### page_info / pagination Support
 
 2019-07 API version introduced a new `Link` header which is used for pagination ([explained here](https://help.shopify.com/en/api/guides/paginated-rest-results)).

--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -132,7 +132,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
                 ->addMiddleware(new AuthRequest($this), 'request:auth')
                 ->addMiddleware(new UpdateApiLimits($this), 'rate:update')
                 ->addMiddleware(new UpdateRequestTime($this), 'time:update')
-                ->addMiddleware(GuzzleRetryMiddleware::factory(), 'request:retry');            
+                ->addMiddleware(GuzzleRetryMiddleware::factory(), 'request:retry');
         }
 
         // Create a default Guzzle client with our stack

--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -120,12 +120,20 @@ class BasicShopifyAPI implements SessionAware, ClientAware
 
         // Create the stack and assign the middleware which attempts to fix redirects
         $this->stack = HandlerStack::create($this->getOptions()->getGuzzleHandler());
-        $this
-            ->addMiddleware(new AuthRequest($this), 'request:auth')
-            ->addMiddleware(new RateLimiting($this), 'rate:limiting')
-            ->addMiddleware(new UpdateApiLimits($this), 'rate:update')
-            ->addMiddleware(new UpdateRequestTime($this), 'time:update')
-            ->addMiddleware(GuzzleRetryMiddleware::factory(), 'request:retry');
+        if ($this->getOptions()->getUseRateLimit()) {
+            $this
+                ->addMiddleware(new AuthRequest($this), 'request:auth')
+                ->addMiddleware(new RateLimiting($this), 'rate:limiting')
+                ->addMiddleware(new UpdateApiLimits($this), 'rate:update')
+                ->addMiddleware(new UpdateRequestTime($this), 'time:update')
+                ->addMiddleware(GuzzleRetryMiddleware::factory(), 'request:retry');
+        } else {
+            $this
+                ->addMiddleware(new AuthRequest($this), 'request:auth')
+                ->addMiddleware(new UpdateApiLimits($this), 'rate:update')
+                ->addMiddleware(new UpdateRequestTime($this), 'time:update')
+                ->addMiddleware(GuzzleRetryMiddleware::factory(), 'request:retry');            
+        }
 
         // Create a default Guzzle client with our stack
         $this->setClient(

--- a/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
+++ b/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
@@ -112,6 +112,7 @@ class RateLimiting extends AbstractMiddleware
         if ($timeDiff < 1000000 && $lastCost > $pointsEverySecond) {
             // Less than a second has passed and the cost is over the limit
             $td->sleep(1000000 - $timeDiff);
+
             return true;
         }
 

--- a/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
+++ b/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
@@ -112,7 +112,6 @@ class RateLimiting extends AbstractMiddleware
         if ($timeDiff < 1000000 && $lastCost > $pointsEverySecond) {
             // Less than a second has passed and the cost is over the limit
             $td->sleep(1000000 - $timeDiff);
-
             return true;
         }
 

--- a/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
+++ b/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
@@ -107,7 +107,7 @@ class RateLimiting extends AbstractMiddleware
 
         // How many points can be spent every second and time difference
         $pointsEverySecond = $api->getOptions()->getGraphLimit();
-        $timeDiff = ($currentTime - $lastTime)*1000000;
+        $timeDiff = ($currentTime - $lastTime) * 1000000;
 
         if ($timeDiff < 1000000 && $lastCost > $pointsEverySecond) {
             // Less than a second has passed and the cost is over the limit

--- a/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
+++ b/src/Osiset/BasicShopifyAPI/Middleware/RateLimiting.php
@@ -107,7 +107,7 @@ class RateLimiting extends AbstractMiddleware
 
         // How many points can be spent every second and time difference
         $pointsEverySecond = $api->getOptions()->getGraphLimit();
-        $timeDiff = $currentTime - $lastTime;
+        $timeDiff = ($currentTime - $lastTime)*1000000;
 
         if ($timeDiff < 1000000 && $lastCost > $pointsEverySecond) {
             // Less than a second has passed and the cost is over the limit

--- a/src/Osiset/BasicShopifyAPI/Options.php
+++ b/src/Osiset/BasicShopifyAPI/Options.php
@@ -161,7 +161,7 @@ class Options
     public function getUseRateLimit(): bool
     {
         return $this->useRateLimit;
-    }  
+    }
 
     /**
      * Sets the API key for use with the Shopify API (public or private apps).

--- a/src/Osiset/BasicShopifyAPI/Options.php
+++ b/src/Osiset/BasicShopifyAPI/Options.php
@@ -24,11 +24,11 @@ class Options
     protected $private = false;
 
     /**
-     * Use GraphQL limit rate.
+     * Use library's limit rate.
      *
      * @var bool
      */
-    protected $useGraphLimit = true;
+    protected $useRateLimit = true;
 
     /**
      * The Shopify API key.
@@ -140,27 +140,27 @@ class Options
     }
 
     /**
-     * Set useGraphLimit to use or not the library's basic method of rate limit.
+     * Set useRateLimit to use or not the library's basic method of rate limit.
      *
-     * @param bool $useGraphLimit True for use library's basic method, false for not use.
+     * @param bool $useRateLimit True for use library's basic method, false for not use.
      *
      * @return self
      */
-    public function setUseGraphLimit(bool $value): self
+    public function setUseRateLimit(bool $value): self
     {
-        $this->useGraphLimit = $value;
+        $this->useRateLimit = $value;
 
         return $this;
     }
 
     /**
-     * Get the useGraphLimit.
+     * Get the useRateLimit.
      *
      * @return bool
      */
-    public function getUseGraphLimit(): bool
+    public function getUseRateLimit(): bool
     {
-        return $this->useGraphLimit;
+        return $this->useRateLimit;
     }  
 
     /**

--- a/src/Osiset/BasicShopifyAPI/Options.php
+++ b/src/Osiset/BasicShopifyAPI/Options.php
@@ -24,6 +24,13 @@ class Options
     protected $private = false;
 
     /**
+     * Use GraphQL limit rate.
+     *
+     * @var bool
+     */
+    protected $useGraphLimit = true;
+
+    /**
      * The Shopify API key.
      *
      * @var string|null
@@ -131,6 +138,30 @@ class Options
     {
         return !$this->isPrivate();
     }
+
+    /**
+     * Set useGraphLimit to use or not the library's basic method of rate limit.
+     *
+     * @param bool $useGraphLimit True for use library's basic method, false for not use.
+     *
+     * @return self
+     */
+    public function setUseGraphLimit(bool $value): self
+    {
+        $this->useGraphLimit = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the useGraphLimit.
+     *
+     * @return bool
+     */
+    public function getUseGraphLimit(): bool
+    {
+        return $this->useGraphLimit;
+    }  
 
     /**
      * Sets the API key for use with the Shopify API (public or private apps).


### PR DESCRIPTION
Hi, fix microseconds issue in GraphQL ratelimiting.php and a new option to use or not the library's rate limit method.

The library's method is basic and it is easy to be throttled.

If you implement your own method, the library will also wait up to 1 second, so may be you will wait twice, so it is better that you could deactivated the library's rate limit method.

use this option: $option->setUseRateLimit(false); 

