### PR TITLE
Merge additional per-user data returned by Shopify with the User

### DIFF
--- a/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
+++ b/src/Osiset/BasicShopifyAPI/BasicShopifyAPI.php
@@ -327,8 +327,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
         // Get the access response data
         $access = $this->requestAccess($code);
 
-        $user = isset($access['associated_user']) ? $access['associated_user'] : null;
-        $session = new Session($this->session->getShop(), $access['access_token'], $user);
+        $session = new Session($this->session->getShop(), $access['access_token'], $access);
 
         // Update the session
         $this->setSession($session);

--- a/src/Osiset/BasicShopifyAPI/Session.php
+++ b/src/Osiset/BasicShopifyAPI/Session.php
@@ -42,8 +42,15 @@ class Session
         $this->shop = $shop;
         $this->accessToken = $accessToken;
 
-        if ($user) {
-            $this->user = $user instanceof ResponseAccess ? $user : new ResponseAccess($user);
+        $associated_user = isset($user['associated_user']) ? $user['associated_user'] : null;
+
+        if ($associated_user) {
+            $associated_user['associated_user_scope'] = isset($user['associated_user_scope']) ? $user['associated_user_scope'] : null;
+            $associated_user['expires_in'] = isset($user['expires_in']) ? $user['expires_in'] : null;
+            $associated_user['session'] = isset($user['session']) ? $user['session'] : null;
+            $associated_user['account_number'] = isset($user['account_number']) ? $user['account_number'] : null;
+
+            $this->user = $associated_user instanceof ResponseAccess ? $associated_user : new ResponseAccess($associated_user);
         }
     }
 


### PR DESCRIPTION
This pull request is to merge the additional fields (listed below) that are returned by Shopify with the existing User object. 

- associated_user_scope
- expires_in
- session
- account_number

I think merging them with the existing user data is the best way to avoid any breaking changes.

I haven't run any tests as I'm not familiar with PHP Unit. 