### PR TITLE
Fix error in REST Rate Limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,9 +524,10 @@ For storing the current request times, API limits, request costs, etc. A basic i
 If you would like to implement a more advananced store such as one with Redis, simply implement `Osiset\BasicShopifyAPI\Contracts\StateStorage` and set the client to use it, example:
 
 ```php
-$redisStore = new RedisStore($connection);
+$timeStore = new RedisStore();
+$limitStore = new RedisStore();
 
-$api = new BasicShopifyAPI($options, $redisStore, $redisStore, $redisStore);
+$api = new BasicShopifyAPI($options, $timeStore, $limitStore);
 ```
 
 ## Documentation

--- a/src/Middleware/RateLimiting.php
+++ b/src/Middleware/RateLimiting.php
@@ -56,7 +56,12 @@ class RateLimiting extends AbstractMiddleware
         }
 
         // Determine if this call has passed the window
-        $firstTime = end($times)['time'];
+        $firstTime = end($times);
+
+        if (is_array($firstTime)) {
+            $firstTime = $firstTime['time'];
+        }
+
         $windowTime = $firstTime + 1000000;
         $currentTime = $td->getCurrentTime();
 

--- a/src/Middleware/RateLimiting.php
+++ b/src/Middleware/RateLimiting.php
@@ -56,13 +56,7 @@ class RateLimiting extends AbstractMiddleware
         }
 
         // Determine if this call has passed the window
-        $firstTime = end($times);
-
-        if (is_array($firstTime)) {
-            $firstTime = $firstTime['time'];
-        }
-
-        $windowTime = $firstTime + 1000000;
+        $windowTime = end($times) + 1000000;
         $currentTime = $td->getCurrentTime();
 
         if ($currentTime > $windowTime) {

--- a/src/Middleware/UpdateApiLimits.php
+++ b/src/Middleware/UpdateApiLimits.php
@@ -107,7 +107,6 @@ class UpdateApiLimits extends AbstractMiddleware
                 'left' => (int) $calls[1] - (int) $calls[0],
                 'made' => (int) $calls[0],
                 'limit' => (int) $calls[1],
-                'time' => $client->getTimeDeferrer()->getCurrentTime(),
             ],
             $this->api->getSession()
         );

--- a/test/Middleware/RateLimitingTest.php
+++ b/test/Middleware/RateLimitingTest.php
@@ -27,20 +27,7 @@ class RateLimitingTest extends BaseTest
 
         // Fill fake times
         $ts = $api->getRestClient()->getTimeStore();
-        $ts->set([
-            [
-                'left' => 38,
-                'made' => 2,
-                'limit' => 40,
-                'time' => $secondTime,
-            ],
-            [
-                'left' => 39,
-                'made' => 1,
-                'limit' => 40,
-                'time' => $firstTime,
-            ],
-        ], $api->getSession());
+        $ts->set([$secondTime, $firstTime], $api->getSession());
 
         // Given we have 2 previous calls within 1 second window, sleep should trigger
         $result = $method->invoke(new RateLimiting($api), $api);
@@ -65,20 +52,7 @@ class RateLimitingTest extends BaseTest
 
         // Fill fake times
         $ts = $api->getRestClient()->getTimeStore();
-        $ts->set([
-            [
-                'left' => 38,
-                'made' => 2,
-                'limit' => 40,
-                'time' => $secondTime,
-            ],
-            [
-                'left' => 39,
-                'made' => 1,
-                'limit' => 40,
-                'time' => $firstTime,
-            ],
-        ], $api->getSession());
+        $ts->set([$secondTime, $firstTime], $api->getSession());
 
         // Even though two requests happened within 1 second window,
         // If we do the "next" call after the window time, it should


### PR DESCRIPTION
To fix #121 

I'm not sure how this came to be an error, considering these lines pushing arrays, and not floats, into the array of times that gets cached:

https://github.com/osiset/Basic-Shopify-API/blob/a83e66891511535ea338e67281892d6e8289a320/src/Middleware/UpdateApiLimits.php#L106:L111

But, this PR checks to see if the item being used from the array is an array, before trying to access it's `time` key.

If I've missed something obvious, please let me know.