### PR TITLE
ResponseAccess::current() should be compatible with Iterator::current()

### DIFF
--- a/src/ResponseAccess.php
+++ b/src/ResponseAccess.php
@@ -57,7 +57,7 @@ class ResponseAccess implements ArrayAccess, Iterator, Countable, JsonSerializab
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($offset === 'container') {
             return $this->container;
@@ -152,7 +152,7 @@ class ResponseAccess implements ArrayAccess, Iterator, Countable, JsonSerializab
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         if (is_array($this->container[$this->position])) {
             return new static($this->container[$this->position]);


### PR DESCRIPTION
Hi there, 

Thanks for this great API!

I had a few error messages using PHP 8.1 like `Return type of Osiset\BasicShopifyAPI\ResponseAccess::current() should either be compatible with Iterator::current(): mixed`

This fixes it :)