### PR TITLE
PHP 8.4 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ $result = $api->graph(...);
 Requests are made using Guzzle.
 
 ```php
-$api->rest(string $type, string $path, array $params = null, array $headers = [], bool $sync = true);
+$api->rest(string $type, string $path, ?array $params = null, array $headers = [], bool $sync = true);
 // or $api->getRestClient()->request(....);
 ```
 

--- a/src/BasicShopifyAPI.php
+++ b/src/BasicShopifyAPI.php
@@ -426,7 +426,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
     /**
      * @see Rest::request
      */
-    public function rest(string $type, string $path, array $params = null, array $headers = [], bool $sync = true)
+    public function rest(string $type, string $path, ?array $params = null, array $headers = [], bool $sync = true)
     {
         return $this->getRestClient()->request($type, $path, $params, $headers, $sync);
     }
@@ -437,7 +437,7 @@ class BasicShopifyAPI implements SessionAware, ClientAware
      *
      * @see rest
      */
-    public function restAsync(string $type, string $path, array $params = null, array $headers = []): Promise
+    public function restAsync(string $type, string $path, ?array $params = null, array $headers = []): Promise
     {
         return $this->rest($type, $path, $params, $headers, false);
     }

--- a/src/Clients/Rest.php
+++ b/src/Clients/Rest.php
@@ -103,7 +103,7 @@ class Rest extends AbstractClient implements RestRequester
     /**
      * {@inheritdoc}
      */
-    public function request(string $type, string $path, array $params = null, array $headers = [], bool $sync = true)
+    public function request(string $type, string $path, ?array $params = null, array $headers = [], bool $sync = true)
     {
         // Build URI
         $uri = $this->getBaseUri()->withPath($path);

--- a/src/Contracts/RestRequester.php
+++ b/src/Contracts/RestRequester.php
@@ -25,7 +25,7 @@ interface RestRequester extends LimitAccesser, TimeAccesser, SessionAware, Clien
      *
      * @return array|Promise
      */
-    public function request(string $type, string $path, array $params = null, array $headers = [], bool $sync = true);
+    public function request(string $type, string $path, ?array $params = null, array $headers = [], bool $sync = true);
 
     /**
      * Gets the access object from a "code" supplied by Shopify request after successfull auth (for public apps).


### PR DESCRIPTION
This fixes the deprecations found in https://github.com/gnikyt/Basic-Shopify-API/issues/151


Closes: https://github.com/gnikyt/Basic-Shopify-API/issues/151