### PR TITLE
Updated dependencies, minimum php version is set to version 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         "source": "https://github.com/gnikyt/basic-shopify-api"
     },
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=8.1.0",
         "ext-json": "*",
-        "caseyamcl/guzzle_retry_middleware": "^2.3",
-        "guzzlehttp/guzzle": "^6.5 || ^7.0"
+        "caseyamcl/guzzle_retry_middleware": "^2.12.1",
+        "guzzlehttp/guzzle": "^7.9.3"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.8",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^6.2 || ^9.3"
+        "ergebnis/composer-normalize": "^2.47",
+        "friendsofphp/php-cs-fixer": "^3.75",
+        "phpstan/phpstan": "^0.12.100",
+        "phpunit/phpunit": "^10.5.46"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="false"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="true"
-         syntaxCheck="true"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="true"
+    bootstrap="./vendor/autoload.php"
 >
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-text" target="php://stdout"/>
-    </logging>
     <testsuites>
         <testsuite name="BasicShopifyAPI Test Suite">
             <directory>./test/</directory>
+            <exclude>./test/BaseTest.php</exclude>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
When changing the minimum PHP version, I based it on the fact that version 8.1 is the minimum supported version (https://www.php.net/supported-versions).

Moreover, it doesn't include any critical changes, and upgrading the PHP version from 7.3 to 8.1 can be done with almost no issues.







